### PR TITLE
Add Python compatibility string

### DIFF
--- a/octoprint_complicated/__init__.py
+++ b/octoprint_complicated/__init__.py
@@ -105,6 +105,7 @@ class ComplicatedPlugin( octoprint.plugin.ProgressPlugin, octoprint.plugin.Setti
 
 __plugin_name__ = 'Complicated Plugin'
 __plugin_version__ = '1.1.3'
+__plugin_pythoncompat__ = ">=2.7,<4"  # python 2 and 3
 __plugin_implementation__ = ComplicatedPlugin()
 __plugin_hooks__ = {
     "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information


### PR DESCRIPTION
Since Python 2 is EOL and all new users very shortly will be Py3, they would not be able to install and run this plugin.

There's the documentation here, if you want to setup dual environments for testing:
https://docs.octoprint.org/en/master/plugins/python3_migration.html

Or, to update your existing environment, one time script:
https://octoprint.org/blog/2020/09/10/upgrade-to-py3/

Closes #8 
Closes #9 

**Please note** I am unable to test this since I don't have the correct hardware, and have not looked at the dependency https://github.com/frenchie4111/complicated-python to check its compatibility 

If you would like to test it, or until this PR gets merged, and you (as a user) want to install the plugin - use this URL in the plugin manager > Get More> ...from URL:
```
https://github.com/cp2004/complicated-octoprint/archive/patch-1.zip
```